### PR TITLE
allow anonymous form-cleaner functions

### DIFF
--- a/src/red_tape/core.clj
+++ b/src/red_tape/core.clj
@@ -243,7 +243,12 @@
             (format "Field names must be keywords; got %s" k)))
 
   (assert
-    (not (or (map? form-cleaners) (list? form-cleaners)))
+    (let [form-cleaners (eval form-cleaners)]
+      (or
+        (nil? form-cleaners)
+        (vector? form-cleaners)
+        (set? form-cleaners)
+        (fn? form-cleaners)))
     (format "Form-level cleaners must be a function, vector, or set; got %s"
             form-cleaners)))
 


### PR DESCRIPTION
Saw your post on HN and wanted to give this a try--looks great, I'm enjoying it!

One problem I ran into:

```
(defform foo
  :bar []
  :red-tape/form (fn [form-data] form-data))
```

failed to pass the sanity check--I got `Assert failed: Form-level cleaners must be a function, vector, or set; got (fn [] form-data)`

To avoid this, instead of trying to make a sanity judgment based on the form `'(fn [form-data] form-data)` itself, I `eval`ed it and ensured that its type was valid. Let me know if you see a better way!

-John
