### PR TITLE
Fix a confusing typo

### DIFF
--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -23,7 +23,7 @@ First you'll define a form:
 
     (defform comment-form
       {:arguments [user]
-       :initial {:email (:email-address user)}}
+       :initial {:email (:email user)}}
 
       :email ^:red-tape/optional
              [#(cleaners/matches #"\S+@\S+" %


### PR DESCRIPTION
Since `:email` is the field that's validated against later on.

I'm not 100% sure on this since I've only spent a few minutes playing with it, but I couldn't get the regex cleaner to fail with the example code as-is, so I suspect this change is right.
